### PR TITLE
Add garbage collection to clean up expired authorizations

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,10 +1,18 @@
 Flownative:
   OAuth2:
     Client:
+      garbageCollection:
+        # The probability in percent of a client shutdown triggering a garbage
+        # collection which removes expired tokens.
+        #
+        # Examples:
+        #    1    (would be a 1% chance to clean up)
+        #   20    (would be a 20% chance to clean up)
+        #    0.42 (would be a 0.42 % chance to clean up)
+        probability: 1
       services: []
 #        - name: 'flownative-beach'
 #          className: 'Flownative\Beach\BeachClient'
-
 
 Neos:
   Flow:


### PR DESCRIPTION
A new setting defines the probability with which expired authorizations
are removed from the persistence layer when the client is shut down by
the Flow framework. It is a float and defaults to 1, meaning 1%.

    Flownative:
      OAuth2:
        Client:
          garbageCollection:
            probability: 1

Examples:

-  1    (would be a 1% chance to clean up)
- 20    (would be a 20% chance to clean up)
-  0.42 (would be a 0.42 % chance to clean up)