### PR TITLE
Allow other providers then GenericProvider

### DIFF
--- a/Classes/OAuthClient.php
+++ b/Classes/OAuthClient.php
@@ -485,7 +485,7 @@ abstract class OAuthClient
      * @param string $clientSecret
      * @return GenericProvider
      */
-    protected function createOAuthProvider(string $clientId, string $clientSecret): GenericProvider
+    protected function createOAuthProvider(string $clientId, string $clientSecret)
     {
         return new GenericProvider([
             'clientId' => $clientId,


### PR DESCRIPTION
Removing strict return type allows for using the abstract class with providers like provided by `league/oauth2-google`