### PR TITLE
Hotfix: generate random authorization id for authorization code flows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
   "require": {
     "neos/flow": "^4.0 || ^5.0 || ^6.0 || dev-master",
     "guzzlehttp/guzzle": "6.3.*",
-    "league/oauth2-client": "2.*"
+    "league/oauth2-client": "2.*",
+    "ramsey/uuid": "^3.0 || ^4.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Addresses #13 in a more or less backwards-compatible way for the 0.x branch