### PR TITLE
Fix "Enabling Encryption" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ by using environment variables.
 ```yaml
 Flownative:
   OAuth2:
-    encryption:
-      base64EncodedKey: 'qpBzrH7icQqBKenvk8wTKROv4qcJNxslzdGo3IKXmws='
+    Client:
+      encryption:
+        base64EncodedKey: 'qpBzrH7icQqBKenvk8wTKROv4qcJNxslzdGo3IKXmws='
 ```
 
 ### Verifying Encryption Configuration


### PR DESCRIPTION
The configuration example for "Enabling Encryption" is missing the `Client` namespace part