### PR TITLE
FEATURE: Token default lifetime

### DIFF
--- a/Classes/OAuthClient.php
+++ b/Classes/OAuthClient.php
@@ -76,6 +76,12 @@ abstract class OAuthClient
     protected $garbageCollectionProbability;
 
     /**
+     * @Flow\InjectConfiguration(path="token.defaultLifetime", package="Flownative.OAuth2.Client")
+     * @var int|null
+     */
+    protected $defaultTokenLifetime;
+
+    /**
      * @var Client
      */
     protected $httpClient;
@@ -261,6 +267,10 @@ abstract class OAuthClient
     {
         $authorizationId = Authorization::generateAuthorizationIdForAuthorizationCodeGrant($this->getServiceType(), $this->getServiceName(), $clientId);
         $authorization = new Authorization($authorizationId, $this->getServiceType(), $clientId, Authorization::GRANT_AUTHORIZATION_CODE, $scope);
+        if ($this->defaultTokenLifetime !== null) {
+            $authorization->setExpires(new \DateTimeImmutable('+ ' . $this->defaultTokenLifetime . ' seconds'));
+        }
+
         $this->logger->info(sprintf('OAuth (%s): Starting authorization %s using client id "%s", a %s bytes long secret and scope "%s".', $this->getServiceType(), $authorization->getAuthorizationId(), $clientId, strlen($clientSecret), $scope));
 
         try {

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -13,6 +13,10 @@ Flownative:
       services: []
 #        - name: 'flownative-beach'
 #          className: 'Flownative\Beach\BeachClient'
+      token:
+
+        # default lifetime of new tokens in seconds
+        defaultLifetime: ~
       encryption:
 
         # A base64-encoded random key, for example generated with ./flow oauth:generateencryptionkey


### PR DESCRIPTION
Adds a configuration option `token.defaultLifetime` that allows to
specify the default expiration of access tokens in seconds.

The default value is `null` (no expiration) for greatest backwards
compatibility.

## Usage:

The following `Settings.yaml` will set the default expiration to
600 seconds (= 10 minutes) in the future:

```yaml
Flownative:
  OAuth2:
    Client:
      token:
        defaultLifetime: 600
```

Resolves: #22