### PR TITLE
Support for Authorization metadata

### DIFF
--- a/Classes/Authorization.php
+++ b/Classes/Authorization.php
@@ -78,6 +78,12 @@ class Authorization
     protected $encryptedSerializedAccessToken;
 
     /**
+     * @var string
+     * @ORM\Column(nullable = true, type = "text")
+     */
+    protected $metadata;
+
+    /**
      * @Flow\Transient
      * @var EncryptionService
      */
@@ -286,5 +292,15 @@ class Authorization
     public function setExpires(\DateTimeImmutable $expires): void
     {
         $this->expires = $expires;
+    }
+
+    public function getMetadata(): ?string
+    {
+        return $this->metadata;
+    }
+
+    public function setMetadata(string $metadata): void
+    {
+        $this->metadata = $metadata;
     }
 }

--- a/Classes/OAuthClient.php
+++ b/Classes/OAuthClient.php
@@ -484,6 +484,26 @@ abstract class OAuthClient
     }
 
     /**
+     * Helper method to set metadate on an Authorization instance, makes sure the
+     * change is persisted.
+     *
+     * @param string $authorizationId
+     * @param string $metadata
+     * @return void
+     */
+    public function setAuthorizationMetadata(string $authorizationId, string $metadata): void
+    {
+        $authorization = $this->getAuthorization($authorizationId);
+        if ($authorization === null) {
+            throw new \RuntimeException('Authorization not found', 1631821719);
+        }
+        $authorization->setMetadata($metadata);
+
+        $this->entityManager->persist($authorization);
+        $this->entityManager->flush();
+    }
+
+    /**
      * @param string $clientId
      * @param string $clientSecret
      * @return GenericProvider

--- a/Classes/OAuthClient.php
+++ b/Classes/OAuthClient.php
@@ -255,7 +255,7 @@ abstract class OAuthClient
      * @return string
      * @throws OAuthClientException
      */
-    public function generateAuthorizationIdForAuthorizationCodeGrant(string $clientId)
+    public function generateAuthorizationIdForAuthorizationCodeGrant(string $clientId): string
     {
         return Authorization::generateAuthorizationIdForAuthorizationCodeGrant($this->getServiceType(), $this->getServiceName(), $clientId);
     }
@@ -278,6 +278,14 @@ abstract class OAuthClient
 
     /**
      * Start OAuth authorization with the Authorization Code flow
+     * based on a specified authorization identifier.
+     *
+     * Note that, if you use this method, it is your responsibility to provide a
+     * meaningful authorization id. You might weaken the security of your
+     * application if you use an id which is deterministic or can be guessed by
+     * an attacker.
+     *
+     * If in doubt, always use startAuthorization() instead.
      *
      * @param string $clientId The client id, as provided by the OAuth server
      * @param string $clientSecret The client secret, provided by the OAuth server
@@ -511,8 +519,8 @@ abstract class OAuthClient
     }
 
     /**
-     * Helper method to set metadate on an Authorization instance, makes sure the
-     * change is persisted.
+     * Helper method to set metadata on an Authorization instance. Changes are
+     * persisted immediately.
      *
      * @param string $authorizationId
      * @param string $metadata
@@ -522,7 +530,7 @@ abstract class OAuthClient
     {
         $authorization = $this->getAuthorization($authorizationId);
         if ($authorization === null) {
-            throw new \RuntimeException('Authorization not found', 1631821719);
+            throw new \RuntimeException(sprintf('Failed setting authorization metadata: authorization %s was not found', $authorizationId), 1631821719);
         }
         $authorization->setMetadata($metadata);
 

--- a/Classes/OAuthClient.php
+++ b/Classes/OAuthClient.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Flownative\OAuth2\Client;
 
@@ -472,10 +473,10 @@ abstract class OAuthClient
         $this->uriBuilder->setCreateAbsoluteUri(true);
 
         try {
-            $uri = $this->uriBuilder->
-            reset()->
-            setCreateAbsoluteUri(true)->
-            uriFor('finishAuthorization', ['serviceType' => $this->getServiceType(), 'serviceName' => $this->getServiceName()], 'OAuth', 'Flownative.OAuth2.Client');
+            $uri = $this->uriBuilder
+                ->reset()
+                ->setCreateAbsoluteUri(true)
+                ->uriFor('finishAuthorization', ['serviceType' => $this->getServiceType(), 'serviceName' => $this->getServiceName()], 'OAuth', 'Flownative.OAuth2.Client');
             return $uri;
         } catch (MissingActionNameException $e) {
             return '';
@@ -527,13 +528,12 @@ abstract class OAuthClient
      */
     public function shutdownObject(): void
     {
-        $decimals = (integer)strlen(strrchr($this->garbageCollectionProbability, '.')) - 1;
+        $decimals = strlen(strrchr($this->garbageCollectionProbability, '.')) - 1;
         $factor = ($decimals > -1) ? $decimals * 10 : 1;
         try {
             if (random_int(1, 100 * $factor) <= ($this->garbageCollectionProbability * $factor)) {
                 $this->removeExpiredAuthorizations();
             }
-        } catch (InvalidQueryException $e) {
         } catch (\Exception $e) {
         }
     }

--- a/Classes/OAuthClient.php
+++ b/Classes/OAuthClient.php
@@ -575,7 +575,8 @@ abstract class OAuthClient
      */
     public function shutdownObject(): void
     {
-        $decimals = strlen(strrchr($this->garbageCollectionProbability, '.')) - 1;
+        $garbageCollectionProbability = (string)$this->garbageCollectionProbability;
+        $decimals = strlen(strrchr($garbageCollectionProbability, '.') ?: '') - 1;
         $factor = ($decimals > -1) ? $decimals * 10 : 1;
         try {
             if (random_int(1, 100 * $factor) <= ($this->garbageCollectionProbability * $factor)) {

--- a/Classes/OAuthClient.php
+++ b/Classes/OAuthClient.php
@@ -249,6 +249,18 @@ abstract class OAuthClient
     }
 
     /**
+     * Returns an authorization id taking the service type and service name into account.
+     *
+     * @param string $clientId
+     * @return string
+     * @throws OAuthClientException
+     */
+    public function generateAuthorizationIdForAuthorizationCodeGrant(string $clientId)
+    {
+        return Authorization::generateAuthorizationIdForAuthorizationCodeGrant($this->getServiceType(), $this->getServiceName(), $clientId);
+    }
+
+    /**
      * Start OAuth authorization with the Authorization Code flow
      *
      * @param string $clientId The client id, as provided by the OAuth server
@@ -260,7 +272,22 @@ abstract class OAuthClient
      */
     public function startAuthorization(string $clientId, string $clientSecret, UriInterface $returnToUri, string $scope): UriInterface
     {
-        $authorizationId = Authorization::generateAuthorizationIdForAuthorizationCodeGrant($this->getServiceType(), $this->getServiceName(), $clientId);
+        $authorizationId = $this->generateAuthorizationIdForAuthorizationCodeGrant($clientId);
+        return $this->startAuthorizationWithId($authorizationId, $clientId, $clientSecret, $returnToUri, $scope);
+    }
+
+    /**
+     * Start OAuth authorization with the Authorization Code flow
+     *
+     * @param string $clientId The client id, as provided by the OAuth server
+     * @param string $clientSecret The client secret, provided by the OAuth server
+     * @param UriInterface $returnToUri URI to return to when authorization is finished
+     * @param string $scope Scope to request for authorization. Must be scope ids separated by space, e.g. "openid profile email"
+     * @return UriInterface The URL the browser should redirect to, asking the user to authorize
+     * @throws OAuthClientException
+     */
+    public function startAuthorizationWithId(string $authorizationId, string $clientId, string $clientSecret, UriInterface $returnToUri, string $scope): UriInterface
+    {
         $authorization = new Authorization($authorizationId, $this->getServiceType(), $clientId, Authorization::GRANT_AUTHORIZATION_CODE, $scope);
         $this->logger->info(sprintf('OAuth (%s): Starting authorization %s using client id "%s", a %s bytes long secret and scope "%s".', $this->getServiceType(), $authorization->getAuthorizationId(), $clientId, strlen($clientSecret), $scope));
 

--- a/Migrations/Mysql/Version20210916194112.php
+++ b/Migrations/Mysql/Version20210916194112.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add metedata column on Authorization table
+ */
+final class Version20210916194112 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add metedata column on Authorization table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE flownative_oauth2_client_authorization ADD metadata LONGTEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE flownative_oauth2_client_authorization DROP metadata');
+    }
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,35 @@ authorization" request. Another example is the client credentials flow,
 where an access token is stored in the authorizations table which is
 needed for executing authorized requests to the respective service.
 
+Authorizations also may contain developer-provided metadata. For
+example, you may attach an account identifier to an authorization when
+an authorization process starts and use that information when
+authorization finishes to make sure that the authorization is only used
+for a specific account (or customer number, or participant id).
+
+To set metadata, you need to know the authorization id when starting the
+authorization code flow. This code could be used in an overloaded
+`startAuthorizationAction()`:
+
+```php
+$authorizationId = $oAuthClient->generateAuthorizationIdForAuthorizationCodeGrant($this->appId);
+$loginUri = $oAuthClient->startAuthorizationWithId(
+    $authorizationId,
+    $this->appId,
+    $this->appSecret,
+    $returnToUri,
+    $scope
+);
+$oAuthClient->setAuthorizationMetadata($authorizationId, json_encode($metadata));
+```
+And later, in `finishAuthorization()`, you may retrieve the metadata as
+follows:
+
+```php
+$authorization = $this->getAuthorization($authorizationId);
+$metadata = json_decode($authorization->getMetadata());
+```
+
 ## Encryption
 
 By default, access tokens are serialized and stored unencrypted in the


### PR DESCRIPTION
Allows to attach metadata to an `Authorization` (even before the login is done.)

When starting the authorization code flow:
```php
$authorizationId = $oAuthClient->generateAuthorizationIdForAuthorizationCodeGrant($this->appId);
$loginUri = $oAuthClient->startAuthorizationWithId(
    $authorizationId,
    $this->appId,
    $this->appSecret,
    $returnToUri,
    $scope
);
$oAuthClient->setAuthorizationMetadata($authorizationId, json_encode($metadata));
```

And when using the authorization later:
```php
$authorization = $this->getAuthorization($authorizationId);
$metadata = json_decode($authorization->getMetadata());
```
