### PR TITLE
Allow guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "neos/flow": "^6.0 || ^7.0 || dev-master",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "league/oauth2-client": "^2.0",
         "ramsey/uuid": "^3.0 || ^4.0",
         "paragonie/sodium_compat": "^1.10"


### PR DESCRIPTION
Taking over version constraints on `guzzlehttp/guzzle` from [thephpleague/oauth2-client](https://github.com/thephpleague/oauth2-client/pull/847).