### PR TITLE
BUGFIX: Prevent state cache from flooding the filesystem

### DIFF
--- a/Classes/OAuthClient.php
+++ b/Classes/OAuthClient.php
@@ -359,6 +359,7 @@ abstract class OAuthClient
         if (empty($stateFromCache)) {
             throw new OAuthClientException(sprintf('OAuth: Finishing authorization failed because oAuth state %s could not be retrieved from the state cache.', $stateIdentifier), 1558956494);
         }
+        $this->stateCache->remove($stateIdentifier);
 
         $authorizationId = $stateFromCache['authorizationId'];
         $clientId = $stateFromCache['clientId'];
@@ -619,6 +620,7 @@ abstract class OAuthClient
         try {
             if (random_int(1, 100 * $factor) <= ($this->garbageCollectionProbability * $factor)) {
                 $this->removeExpiredAuthorizations();
+                $this->stateCache->collectGarbage();
             }
         } catch (\Exception $e) {
         }


### PR DESCRIPTION
Adjusts the `OAuthClient` such that it removes any state cache entries directly after usage. Additionally this change extends the garbage collection to remove expired state caches (to remove expired entries after failed or aborted authorizations)

Fixes: #31