### PR TITLE
Raise dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
         }
     ],
     "require": {
-        "php": "8.0.* || 8.1.* || 8.2.* || 8.3.*",
-        "neos/flow": "^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "php": "8.1.* || 8.2.* || 8.3.* || 8.4.*",
+        "neos/flow": "^7.3 || ^8.0 || ^9.0",
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
-        "league/oauth2-client": "^2.0",
+        "league/oauth2-client": "^2.6",
         "ramsey/uuid": "^3.0 || ^4.0",
         "paragonie/sodium_compat": "^1.10"
     },


### PR DESCRIPTION
- minimum PHP is now 8.1
- minimum neos/flow is now 7.4
- minimum league/oauth2-client is now 2.6